### PR TITLE
Restore Crimson Bean

### DIFF
--- a/modules/controls/speed_multiplier.lua
+++ b/modules/controls/speed_multiplier.lua
@@ -33,7 +33,7 @@ Handy.speed_multiplier = {
 					events_count = events_count + #v
 				end
 				if events_count > 1 then
-					queue:update(0, true)
+					queue:update(0)
 				else
 					break
 				end


### PR DESCRIPTION
https://github.com/SleepyG11/HandyBalatro/issues/55 details an issue where the Crimson Bean Exploit doesn't operate on game speeds above 128x. This is due to the forced queue updates disrupting event ordering during run loading which breaks the Crimson Heart and Turtle Bean exploit. Removing ```forced=true``` from the retrigger calls fixes it and preserves the speed gains from having animation skip active.

As mentioned by @PrincessEev, 256x/512x speed are the only speeds broken, this is because ```(queue_retriggers_count >= 3)```, and passing ```forced=true``` to ```queue:update()``` bypasses blocking events and disrupts the sequential ordering of vanilla state-restoration events during run loading. However, as @SleepyG11 said, at <=128x, ```(retriggers_count <= 1)```, therefore the exploit is unaffected because only one extra forced pass fires per frame, which isn't enough to push sequential loading events into the same frame.